### PR TITLE
Release 0.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-bittensor==9.0.2
+bittensor==9.1.0
 starlette>=0.30.0
 pydantic>=2
 

--- a/zeus/__init__.py
+++ b/zeus/__init__.py
@@ -17,7 +17,7 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 version_split = __version__.split(".")
 __spec_version__ = (
     (1000 * int(version_split[0]))

--- a/zeus/utils/config.py
+++ b/zeus/utils/config.py
@@ -197,7 +197,7 @@ def add_validator_args(cls, parser):
         "--neuron.sample_size",
         type=int,
         help="The number of miners to query in a single step.",
-        default=50,
+        default=125,
     )
 
     parser.add_argument(
@@ -211,7 +211,7 @@ def add_validator_args(cls, parser):
         "--neuron.moving_average_alpha",
         type=float,
         help="Moving average alpha parameter, how much to add of the new observation.",
-        default=0.1,
+        default=0.2,
     )
 
     parser.add_argument(

--- a/zeus/validator/constants.py
+++ b/zeus/validator/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 TESTNET_UID = 301
 MAINNET_UID = 18
 
-FORWARD_DELAY_SECONDS = 360
+FORWARD_DELAY_SECONDS = 90
 
 # ERA5 data loading constants
 GCLOUD_ERA5_URL: str = (


### PR DESCRIPTION
# Release 0.1.1 - Validator Update - Hotfix 

### Changes
We've noticed that the number of queries per miner was too low, leading to slow incentive growth. To address this, we've immediately implemented the following small changes:

- Increased the moving average **alpha**, so incentive scores will increase after fewer correct responses
- Increased number of miners queried per challenge from 50 to 125
- Reduced the validator query interval from 6 minutes to 90 seconds

### Explanation
Some validators are still running the Cortex code—we’re working on getting them to switch to Zeus. We felt this needed to be a hotfix to ensure a fair playground for all miners. Miners, no action is required on your end. If you are running the base miner code, just make sure you are aware of OpenMeteo's rate limit. 

This fix should speed up incentive distribution right away. ⚡