### PR TITLE
Release 1.1.1 - Hotfix

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -72,6 +72,10 @@ class Validator(BaseValidatorNeuron):
         """
         return await forward(self)
     
+    def prune_hotkeys(self, hotkeys):
+        if self.is_running: # make sure init is finalised
+            self.database.prune_hotkeys(hotkeys)
+    
     def __exit__(self, exc_type, exc_value, traceback):
         super().__exit__(exc_type, exc_value, traceback)
         self.validator_proxy.stop_server()

--- a/zeus/__init__.py
+++ b/zeus/__init__.py
@@ -17,7 +17,7 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 version_split = __version__.split(".")
 __spec_version__ = (
     (1000 * int(version_split[0]))

--- a/zeus/validator/constants.py
+++ b/zeus/validator/constants.py
@@ -17,8 +17,8 @@ WANDB_MAX_LOGS = 95_000
 
 # the variables miners are tested on, with their respective sampling weight
 ERA5_DATA_VARS: Dict[str, float] = {
-    "2m_temperature": 0.8, 
-    "total_precipitation": 0.2
+    "2m_temperature": 0.7, 
+    "total_precipitation": 0.3
 }
 ERA5_LATITUDE_RANGE: Tuple[float, float] = (-90.0, 90.0)
 ERA5_LONGITUDE_RANGE: Tuple[float, float] = (-180.0, 179.75)  # real ERA5 ranges


### PR DESCRIPTION
### Hotfix: no longer get incentive for old challenges if you re-register a hotkey
This update addresses an important issue where miners could use their old predictions to score, even after being deregistered for a while.
We noticed some miners with high incentives and a non-served axon—this hotfix ensures that only active, serving miners can have their predictions scored.
Old predictions from deregistered miners will now be filtered out.
This should keep the playing field fair and the subnet healthy for everyone.
Since miners have been making a good start on precipitation forecasting, we also slightly increased the probability of precipitation  challenges, they now make up 30% of the total distribution.

**No action is required for validators or miners** — all validators logging to W&B have auto-update enabled, so you’re already protected by this fix!
Happy mining! ⚡