### PR TITLE
⚡ Release 1.1.2 – Precipitation Gets Equal Play!

### DIFF
--- a/zeus/__init__.py
+++ b/zeus/__init__.py
@@ -17,7 +17,7 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"
 version_split = __version__.split(".")
 __spec_version__ = (
     (1000 * int(version_split[0]))

--- a/zeus/validator/constants.py
+++ b/zeus/validator/constants.py
@@ -17,8 +17,8 @@ WANDB_MAX_LOGS = 95_000
 
 # the variables miners are tested on, with their respective sampling weight
 ERA5_DATA_VARS: Dict[str, float] = {
-    "2m_temperature": 0.7, 
-    "total_precipitation": 0.3
+    "2m_temperature": 0.5, 
+    "total_precipitation": 0.5
 }
 ERA5_LATITUDE_RANGE: Tuple[float, float] = (-90.0, 90.0)
 ERA5_LONGITUDE_RANGE: Tuple[float, float] = (-180.0, 179.75)  # real ERA5 ranges
@@ -36,7 +36,7 @@ REWARD_IMPROVEMENT_WEIGHT = 0.5 # 50% of emission for improving SOTA
 # RMSE improvement over OpenMeteo only counts if more than this
 REWARD_IMPROVEMENT_MIN_DELTA: Dict[str, float] = {
     "2m_temperature": 0.1, 
-    "total_precipitation": 0.0005
+    "total_precipitation": 0.00001
 }
 
 # ------------------------------------------------------


### PR DESCRIPTION
We’re excited to announce that precipitation challenges are now queried just as often as temperature—moving from a 70/30 split to a true 50/50 distribution. This change is designed to further incentivize miners to push the state-of-the-art on precipitation forecasting, as this variable is now a core part of the challenge set.

Why this matters:
With precipitation now featured in half of all challenges, miners are encouraged to develop and refine models that excel not just at temperature, but also at this newly introduced and important variable. This is a key step in our mission to expand the range and quality of weather predictions on Zeus.

No action required:
- Validators that currently log to Weights & Biases are all on auto-update—no manual intervention needed.
- The challenge format itself is unchanged; only the distribution has shifted. So miners will not need to update their code.

Let’s see who can set the new benchmark for precipitation!

_The Zeus team_